### PR TITLE
Remove experimental docker feature usage

### DIFF
--- a/images/Makefile.common.in
+++ b/images/Makefile.common.in
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 # shared makefile for all images
 
 # get image name from directory we're building
@@ -37,7 +40,7 @@ OUTPUT?=
 PROGRESS=auto
 EXTRA_BUILD_OPT?=
 build: ensure-buildx ocne_tar
-	docker buildx build --platform=${PLATFORMS} $(OUTPUT) --progress=$(PROGRESS) -t ${IMAGE} --pull $(EXTRA_BUILD_OPT) .
+	docker buildx build $(OUTPUT) --progress=$(PROGRESS) -t ${IMAGE} --pull $(EXTRA_BUILD_OPT) .
 
 # push the cross built image
 push: OUTPUT=--push

--- a/pkg/build/nodeimage/buildcontext.go
+++ b/pkg/build/nodeimage/buildcontext.go
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package nodeimage
 
 import (
@@ -320,7 +323,6 @@ func (c *buildContext) createBuildContainer() (id string, err error) {
 			// the container should hang forever so we can exec in it
 			"--entrypoint=sleep",
 			"--name=" + id,
-			"--platform=" + dockerBuildOsAndArch(c.arch),
 			"--security-opt", "seccomp=unconfined", // ignore seccomp
 		},
 		[]string{

--- a/pkg/build/nodeimage/internal/container/docker/pull.go
+++ b/pkg/build/nodeimage/internal/container/docker/pull.go
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package docker
 
 import (
@@ -26,14 +29,14 @@ import (
 // Pull pulls an image, retrying up to retries times
 func Pull(logger log.Logger, image string, platform string, retries int) error {
 	logger.V(1).Infof("Pulling image: %s for platform %s ...", image, platform)
-	err := exec.Command("docker", "pull", "--platform="+platform, image).Run()
+	err := exec.Command("docker", "pull", image).Run()
 	// retry pulling up to retries times if necessary
 	if err != nil {
 		for i := 0; i < retries; i++ {
 			time.Sleep(time.Second * time.Duration(i+1))
 			logger.V(1).Infof("Trying again to pull image: %q ... %v", image, err)
 			// TODO(bentheelder): add some backoff / sleep?
-			err = exec.Command("docker", "pull", "--platform="+platform, image).Run()
+			err = exec.Command("docker", "pull", image).Run()
 			if err == nil {
 				break
 			}


### PR DESCRIPTION
Remove usage of `--platform` from `docker buildx` and `docker pull` so that we don't require docker experimental features to be enabled to build the kind images.

I tested the node image built with these changes and the cluster is created successfully.