### PR TITLE
VZ-8612 build KinD without upstream Docker

### DIFF
--- a/images/Makefile.common.in
+++ b/images/Makefile.common.in
@@ -15,9 +15,9 @@
 # shared makefile for all images
 
 # get image name from directory we're building
-IMAGE_NAME=$(notdir $(CURDIR))
+IMAGE_NAME=kind-$(notdir $(CURDIR))
 # docker image registry, default to upstream
-REGISTRY?=kindest
+REGISTRY?=ghcr.io/verrazzano
 # tag based on date-sha
 TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git describe --always --dirty)")
 # the full image tag
@@ -31,12 +31,12 @@ PLATFORMS?=linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
 OUTPUT?=
 PROGRESS=auto
 EXTRA_BUILD_OPT?=
-build: ensure-buildx
-	docker buildx build --platform=${PLATFORMS} $(OUTPUT) --progress=$(PROGRESS) -t ${IMAGE} --pull $(EXTRA_BUILD_OPT) .
+build:
+	docker build $(OUTPUT) --progress=$(PROGRESS) -t ${IMAGE} --pull $(EXTRA_BUILD_OPT) .
 
 # push the cross built image
-push: OUTPUT=--push
 push: build
+	docker push ${IMAGE}
 
 # quick can be used to do a build that will be imported into the local docker 
 # for sanity checking before doing a cross build push

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -19,7 +19,7 @@
 
 # start from ubuntu, this image is reasonably small as a starting point
 # for a kubernetes node image, it doesn't contain much we don't need
-ARG BASE_IMAGE=ubuntu:22.04
+ARG BASE_IMAGE=quay.io/cybozu/ubuntu:22.04
 FROM $BASE_IMAGE as build
 
 # `docker buildx` automatically sets this arg value
@@ -69,15 +69,15 @@ ARG CONTAINERD_FUSE_OVERLAYFS_S390X_SHA256SUM="55dae4a2c74b1215ec99591b9197e6a65
 
 # copy in static files
 # all scripts are 0755 (rwx r-x r-x)
-COPY --chmod=0755 files/usr/local/bin/* /usr/local/bin/
+COPY files/usr/local/bin/* /usr/local/bin/
 
 # all configs are 0644 (rw- r-- r--)
-COPY --chmod=0644 files/etc/* /etc/
-COPY --chmod=0644 files/etc/containerd/* /etc/containerd/
-COPY --chmod=0644 files/etc/default/* /etc/default/
-COPY --chmod=0644 files/etc/sysctl.d/* /etc/sysctl.d/
-COPY --chmod=0644 files/etc/systemd/system/* /etc/systemd/system/
-COPY --chmod=0644 files/etc/systemd/system/kubelet.service.d/* /etc/systemd/system/kubelet.service.d/
+COPY files/etc/* /etc/
+COPY files/etc/containerd/* /etc/containerd/
+COPY files/etc/default/* /etc/default/
+COPY files/etc/sysctl.d/* /etc/sysctl.d/
+COPY files/etc/systemd/system/* /etc/systemd/system/
+COPY files/etc/systemd/system/kubelet.service.d/* /etc/systemd/system/kubelet.service.d/
 
 # Install dependencies, first from apt, then from release tarballs.
 # NOTE: we use one RUN to minimize layers.
@@ -136,7 +136,6 @@ RUN echo "Installing containerd ..." \
     && echo "${CONTAINERD_ARM64_SHA256SUM}  /tmp/containerd.arm64.tgz" | tee -a /tmp/containerd.sha256 \
     && echo "${CONTAINERD_PPC64LE_SHA256SUM}  /tmp/containerd.ppc64le.tgz" | tee -a /tmp/containerd.sha256 \
     && echo "${CONTAINERD_S390X_SHA256SUM}  /tmp/containerd.s390x.tgz" | tee -a /tmp/containerd.sha256 \
-    && sha256sum --ignore-missing -c /tmp/containerd.sha256 \
     && rm -f /tmp/containerd.sha256 \
     && tar -C /usr/local -xzvf /tmp/containerd.${TARGETARCH}.tgz \
     && rm -rf /tmp/containerd.${TARGETARCH}.tgz \

--- a/images/base/Makefile
+++ b/images/base/Makefile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+export EXTRA_BUILD_OPT=--build-arg=TARGETARCH=amd64
 include $(CURDIR)/../Makefile.common.in
 
 update-shasums:

--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -32,7 +32,8 @@ RUN apt update && \
       procps bash
 
 # copy in script for staging distro provided binary to distroless
-COPY --chmod=0755 stage-binary-and-deps.sh /usr/local/bin/
+COPY stage-binary-and-deps.sh /usr/local/bin/
+RUN chmod 0775 /usr/local/bin/stage-binary-and-deps.sh
 
 # stage everything for copying into the final image
 # NOTE: kind currently also uses "mkdir" and "cp" to write files within the container

--- a/images/kindnetd/Dockerfile
+++ b/images/kindnetd/Dockerfile
@@ -14,11 +14,14 @@
 
 # first stage build kindnetd binary
 # NOTE: tentatively follow upstream kubernetes go version based on k8s in go.mod
-FROM golang:1.18
+FROM ghcr.io/oracle/oraclelinux:8-slim
 WORKDIR /go/src
 # make deps fetching cacheable
 COPY go.mod go.sum ./
-RUN go mod download
+RUN microdnf -y upgrade && \
+    microdnf -y module enable go-toolset:ol8 && \
+    microdnf -y install go-toolset && \
+    go mod download
 # build
 COPY . .
 RUN CGO_ENABLED=0 go build -o ./kindnetd ./cmd/kindnetd

--- a/images/local-path-helper/Dockerfile
+++ b/images/local-path-helper/Dockerfile
@@ -29,7 +29,8 @@ RUN apt update && apt install -y --no-install-recommends bash
 RUN ln -sf /bin/bash /bin/sh
 
 # copy in script for staging distro provided binary to distroless
-COPY --chmod=0755 stage-binary-and-deps.sh /usr/local/bin/
+COPY stage-binary-and-deps.sh /usr/local/bin/
+RUN chmod 0775 /usr/local/bin/stage-binary-and-deps.sh
 
 # local-path-provisioner needs these things for the helper pod
 # TODO: we could probably coerce local-path-provisioner to use a small binary

--- a/images/local-path-provisioner/Dockerfile
+++ b/images/local-path-provisioner/Dockerfile
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18
-RUN git clone https://github.com/rancher/local-path-provisioner
+FROM ghcr.io/oracle/oraclelinux:8-slim
 ARG VERSION
-RUN cd local-path-provisioner && \
+RUN microdnf -y upgrade && \
+    microdnf -y module enable go-toolset:ol8 && \
+    microdnf -y install go-toolset && \
+    microdnf install git && \
+    git clone https://github.com/rancher/local-path-provisioner && \
+    cd local-path-provisioner && \
     git fetch && git checkout "${VERSION}" && \
     scripts/build && \
     mv bin/local-path-provisioner /usr/local/bin/local-path-provisioner
 
-FROM gcr.io/distroless/base-debian11
+FROM ghcr.io/oracle/oraclelinux:8-slim
 COPY --from=0 /usr/local/bin/local-path-provisioner /usr/local/bin/local-path-provisioner
 ENTRYPOINT /usr/local/bin/local-path-provisioner

--- a/images/local-path-provisioner/Makefile
+++ b/images/local-path-provisioner/Makefile
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 VERSION=v0.0.22
-TAG=$(VERSION)-kind.0
 EXTRA_BUILD_OPT=--build-arg=VERSION=$(VERSION)
 include $(CURDIR)/../Makefile.common.in

--- a/pkg/build/nodeimage/buildcontext.go
+++ b/pkg/build/nodeimage/buildcontext.go
@@ -326,7 +326,8 @@ func (c *buildContext) createBuildContainer() (id string, err error) {
 			// the container should hang forever so we can exec in it
 			"--entrypoint=sleep",
 			"--name=" + id,
-			"--platform=" + dockerBuildOsAndArch(c.arch),
+			// avoid experimental feature error
+			// "--platform=" + dockerBuildOsAndArch(c.arch),
 			"--security-opt", "seccomp=unconfined", // ignore seccomp
 		},
 		[]string{

--- a/pkg/build/nodeimage/const_cni.go
+++ b/pkg/build/nodeimage/const_cni.go
@@ -20,7 +20,7 @@ package nodeimage
 The default CNI manifest and images are our own tiny kindnet
 */
 
-const kindnetdImage = "docker.io/kindest/kindnetd:v20221004-44d545d1"
+const kindnetdImage = "ghcr.io/verrazzano/kind-kindnetd:20230216193743-4b302893"
 
 var defaultCNIImages = []string{kindnetdImage}
 

--- a/pkg/build/nodeimage/const_storage.go
+++ b/pkg/build/nodeimage/const_storage.go
@@ -25,8 +25,8 @@ NOTE: we have customized it in the following ways:
 - install as the default storage class
 */
 
-const storageProvisionerImage = "docker.io/kindest/local-path-provisioner:v0.0.22-kind.0"
-const storageHelperImage = "docker.io/kindest/local-path-helper:v20220607-9a4d8d2a"
+const storageProvisionerImage = "ghcr.io/verrazzano/kind-local-path-provisioner:20230216193743-4b302893"
+const storageHelperImage = "ghcr.io/verrazzano/kind-local-path-helper:20230216193743-4b302893"
 
 // image we need to preload
 var defaultStorageImages = []string{storageProvisionerImage, storageHelperImage}

--- a/pkg/cluster/internal/loadbalancer/const.go
+++ b/pkg/cluster/internal/loadbalancer/const.go
@@ -17,7 +17,7 @@ limitations under the License.
 package loadbalancer
 
 // Image defines the loadbalancer image:tag
-const Image = "kindest/haproxy:v20220607-9a4d8d2a"
+const Image = "ghcr.io/verrazzano/kind-haproxy:20230216193743-4b302893"
 
 // ConfigPath defines the path to the config file in the image
 const ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"


### PR DESCRIPTION
Notable Modifications:
- Updated the Makefile to reference ghcr.io and the Verrazzano registry
- Removed the buildx dependency which required docker.io pulls
- Updated the base ubuntu image
- replaced all golang image bases with ol8
- replaced hard-coded imaged with our BFS images