### PR TITLE
Downgrade base image to ubuntu 20

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -19,7 +19,7 @@
 
 # start from ubuntu, this image is reasonably small as a starting point
 # for a kubernetes node image, it doesn't contain much we don't need
-ARG BASE_IMAGE=quay.io/cybozu/ubuntu:22.04
+ARG BASE_IMAGE=quay.io/cybozu/ubuntu:20.04
 FROM $BASE_IMAGE as build
 
 # `docker buildx` automatically sets this arg value


### PR DESCRIPTION
Due to known issue with higher systemd version, the other possible way with minimal changes will be to downgrade the base image to ubuntu 20.